### PR TITLE
Minimal changes for production usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Manage service for OpenSlides which provides some management commands. The
 service listens on the port given by environment variable `MANAGE_SERVICE_PORT`
-(default 8001) and uses [gRPC](https://grpc.io/).
+(default 9008) and uses [gRPC](https://grpc.io/).
 
 The client used as follows:
 

--- a/entrypoint
+++ b/entrypoint
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+while ! nc -z "$DATASTORE_WRITER_HOST" "$DATASTORE_WRITER_PORT" 2> /dev/null; do
+    echo "waiting for $DATASTORE_WRITER_HOST:$DATASTORE_WRITER_PORT"
+    sleep 1
+done
+echo "$DATASTORE_WRITER_HOST:$DATASTORE_WRITER_PORT is available"
+
+while ! nc -z "$AUTH_HOST" "$AUTH_PORT" 2> /dev/null; do
+    echo "waiting for $AUTH_HOST:$AUTH_PORT"
+    sleep 1
+done
+echo "$AUTH_HOST:$AUTH_PORT is available"
+
+exec "$@"

--- a/entrypoint-setup
+++ b/entrypoint-setup
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+warn_insecure_admin() {
+  cat <<-EOF
+                 ==============================================
+                                    WARNING
+                 ==============================================
+                 WARNING: INSECURE ADMIN ACCOUNT CONFIGURATION!
+EOF
+  sleep 10
+}
+
+MANAGE_HOST="${MANAGE_HOST:-manage}"
+MANAGE_PORT="${MANAGE_PORT:-9008}"
+
+while ! nc -z "$MANAGE_HOST" "$MANAGE_PORT" 2> /dev/null; do
+    echo "waiting for $MANAGE_HOST:$MANAGE_PORT"
+    sleep 1
+done
+echo "$MANAGE_HOST:$MANAGE_PORT is available"
+
+source /run/secrets/admin || true
+[[ -n "$OPENSLIDES_ADMIN_PASSWORD" ]] || {
+  warn_insecure_admin
+  OPENSLIDES_ADMIN_PASSWORD="admin"
+}
+
+./manage --address "$MANAGE_HOST:$MANAGE_PORT" set-password --user_id 1 --password "$OPENSLIDES_ADMIN_PASSWORD"
+
+exit 0

--- a/pkg/manage/server.go
+++ b/pkg/manage/server.go
@@ -22,7 +22,7 @@ func RunServer(cfg *ServerConfig) error {
 	s := grpc.NewServer()
 	proto.RegisterManageServer(s, newServer(cfg))
 
-	fmt.Printf("Running manage service on %s", addr)
+	fmt.Printf("Running manage service on %s\n", addr)
 
 	if err := s.Serve(lis); err != nil {
 		return fmt.Errorf("running service: %w", err)
@@ -90,7 +90,7 @@ func ServerConfigFromEnv(loockup func(string) (string, bool)) *ServerConfig {
 
 // Addr return the address of the manage service.
 func (c *ServerConfig) Addr() string {
-	return c.Host + ":" + c.Port
+	return ":" + c.Port
 }
 
 // AuthURL returns an URL object to the auth service with empty path.


### PR DESCRIPTION
"minimal" describes the kind of changes: They are just the bare minimum
required to start it in the production setup and only set the admin
password to either the secret given or the default "admin".

I've added a entrypoint to wait for dependend services. Otherwise I got
errors, that e.g. the datastore is not reachable.

I've added a entrypoint-setup which is used as a one-time container: In
it, the necessary manage commands are executed when the setup starts.
More things to do will follow (like configurating the organization and
so on). This must be done in a docker context to have this automatically
run. The way we run our prod setup is that it must be self-contained -
it is configured through env/secrets and after a deployment it must be
ready. This is why I execute ./manage in the dockercontainer itself.

More changes:
- The service now has the preallocated port 9008
- The EXEC format in the dockerfile has not the recommended format

Some changes needs to be cleaned up later:
- All print/log statements are missing \n
- The server must not listen on `MANAGE_HOST`. If so, no other service
can reach the container. I just removed the host form the address, maybe
this needs to be refactored later.

And yes, I used bash. Because it gets the job done and this is a part,
where also our server maintainers will change stuff - and bash is a
commonly known tool which can be easily scripted.

I'll merge this fast since we need this to have our prod setup running
for our client. I'll write an email with additionally needs that can be
implemented later on.