### PR TITLE
Make the service production ready (again)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ COPY proto proto
 
 # Build service in seperate stage.
 FROM base as builder
-RUN RUN CGO_ENABLED=0 go build ./cmd/server
-
+RUN CGO_ENABLED=0 go build ./cmd/server
+RUN CGO_ENABLED=0 go build ./cmd/manage
 
 # Test build.
 FROM base as testing
@@ -35,7 +35,13 @@ CMD CompileDaemon -log-prefix=false -build="go build ./cmd/server" -command="./s
 
 
 # Productive build.
-FROM scratch
+FROM alpine:3.13.2
+WORKDIR /root/
+RUN apk add bash
+
 COPY --from=builder /root/server .
+COPY --from=builder /root/manage .
+COPY entrypoint-setup .
+
 EXPOSE 9008
-ENTRYPOINT ["/server"]
+CMD ["/root/server"]

--- a/entrypoint-setup
+++ b/entrypoint-setup
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+set -e
+
+warn_insecure_admin() {
+  cat <<-EOF
+                 ==============================================
+                                    WARNING
+                 ==============================================
+                 WARNING: INSECURE ADMIN ACCOUNT CONFIGURATION!
+EOF
+  sleep 10
+}
+
+MANAGE_HOST="${MANAGE_HOST:-manage}"
+MANAGE_PORT="${MANAGE_PORT:-9008}"
+
+# Wait for manage service
+while ! nc -z "$MANAGE_HOST" "$MANAGE_PORT" 2> /dev/null; do
+    echo "waiting for $MANAGE_HOST:$MANAGE_PORT"
+    sleep 1
+done
+echo "$MANAGE_HOST:$MANAGE_PORT is available"
+
+# Wait for management dependent services
+# This does not work
+#while ! ./manage --address "$MANAGE_HOST:$MANAGE_PORT" --timeout 1s check-server 2> /dev/null; do
+#    echo "waiting for dependent services"
+#done
+#echo "Dependent services are online"
+
+while ! nc -z "$DATASTORE_WRITER_HOST" "$DATASTORE_WRITER_PORT" 2> /dev/null; do
+    echo "waiting for $DATASTORE_WRITER_HOST:$DATASTORE_WRITER_PORT"
+    sleep 1
+done
+echo "$DATASTORE_WRITER_HOST:$DATASTORE_WRITER_PORT is available"
+
+while ! nc -z "$DATASTORE_READER_HOST" "$DATASTORE_READER_PORT" 2> /dev/null; do
+    echo "waiting for $DATASTORE_READER_HOST:$DATASTORE_READER_PORT"
+    sleep 1
+done
+echo "$DATASTORE_READER_HOST:$DATASTORE_READER_PORT is available"
+
+while ! nc -z "$AUTH_HOST" "$AUTH_PORT"; do
+    echo "waiting for $AUTH_HOST:$AUTH_PORT"
+    sleep 1
+done
+echo "$AUTH_HOST:$AUTH_PORT is available"
+
+# Set admin password
+source /run/secrets/admin || true
+[[ -n "$OPENSLIDES_ADMIN_PASSWORD" ]] || {
+    warn_insecure_admin
+    OPENSLIDES_ADMIN_PASSWORD="admin"
+}
+./manage --address "$MANAGE_HOST:$MANAGE_PORT" set-password --user_id 1 --password "$OPENSLIDES_ADMIN_PASSWORD"
+
+# Enable/Disable electronic voting
+argument="disabled"
+if [[ -n $ENABLE_ELECTRONIC_VOTING ]]; then
+    argument="enabled"
+fi
+./manage --address "$MANAGE_HOST:$MANAGE_PORT" config set voting $argument
+echo "$argument electronic voting"
+
+exit 0

--- a/pkg/manage/cmd_config.go
+++ b/pkg/manage/cmd_config.go
@@ -117,7 +117,7 @@ func (s *Server) Config(ctx context.Context, in *proto.ConfigRequest) (*proto.Co
 
 	if in.NewValue == "" {
 		// Fetch value
-		waitForService(ctx, s.config.DatastoreReaderHost, s.config.DatastoreReaderPort)
+		// waitForService(ctx, s.config.DatastoreReaderHost, s.config.DatastoreReaderPort)
 
 		addr := fmt.Sprintf("%s://%s:%s", s.config.DatastoreReaderProtocol, s.config.DatastoreReaderHost, s.config.DatastoreReaderPort)
 		var enabled bool
@@ -134,7 +134,7 @@ func (s *Server) Config(ctx context.Context, in *proto.ConfigRequest) (*proto.Co
 	}
 
 	// Write value
-	waitForService(ctx, s.config.DatastoreWriterHost, s.config.DatastoreWriterPort)
+	// waitForService(ctx, s.config.DatastoreWriterHost, s.config.DatastoreWriterPort)
 
 	var value []byte
 	switch in.NewValue {

--- a/pkg/manage/cmd_set_password.go
+++ b/pkg/manage/cmd_set_password.go
@@ -62,8 +62,8 @@ func CmdSetPassword(cfg *ClientConfig) *cobra.Command {
 
 // SetPassword sets hashes and sets the password
 func (s *Server) SetPassword(ctx context.Context, in *proto.SetPasswordRequest) (*proto.SetPasswordResponse, error) {
-	waitForService(ctx, s.config.AuthHost, s.config.AuthPort)
-	waitForService(ctx, s.config.DatastoreWriterHost, s.config.DatastoreWriterPort)
+	// waitForService(ctx, s.config.AuthHost, s.config.AuthPort)
+	// waitForService(ctx, s.config.DatastoreWriterHost, s.config.DatastoreWriterPort)
 
 	hash, err := hashPassword(ctx, s.config, in.Password)
 	if err != nil {


### PR DESCRIPTION
- Temporary disabled waitForService (see
https://github.com/OpenSlides/openslides-manage-service/issues/18)
- readded entrypoint-setup since no alternative was provided. Also
redone changes in the Dockerfile needed for the setup script
- Fixed a duplicate "RUN" in the dockerfile

I wonder why you deleted files without providing alternatives at all.
This broke the productive deployment.

I won't merge this now, but we will use this branch in our productive environment until working alternatives are present.

You can use this as the reference for the expected behavior of the productive setup