### PR TITLE
add backend-setup for one time setup actions

### DIFF
--- a/pkg/setup/default-docker-compose.yml
+++ b/pkg/setup/default-docker-compose.yml
@@ -89,6 +89,25 @@ services:
       - auth_token_key
       - auth_cookie_key
 
+  backend-setup:
+    image: ghcr.io/openslides/openslides/openslides-backend:4.0.0-dev
+    entrypoint: "./entrypoint-setup.sh"
+    depends_on:
+      - datastore-reader
+      - datastore-writer
+      - auth
+      - postgres
+    environment:
+      << : *default-environment
+    networks:
+      - frontend
+      - datastore-reader
+      - datastore-writer
+      - postgres
+    secrets:
+      - auth_token_key
+      - auth_cookie_key
+
   datastore-reader:
     image: ghcr.io/openslides/openslides/openslides-datastore-reader:4.0.0-dev
     depends_on:


### PR DESCRIPTION
this will extend the template for the docker-compose file by a backend-setup container with the entrypoint overridden to entrypoint-setup.