### PR TITLE
Add backend-setup service definition and changed docker compose file (renaming, networks etc.)

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -221,6 +221,7 @@ func newYmlConfig(configFiles [][]byte) (*ymlConfig, error) {
 		"proxy",
 		"client",
 		"backend",
+		"backendSetup",
 		"datastoreReader",
 		"datastoreWriter",
 		"postgres",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -221,7 +221,7 @@ func newYmlConfig(configFiles [][]byte) (*ymlConfig, error) {
 		"proxy",
 		"client",
 		"backend",
-		"backendSetup",
+		"backendManage",
 		"datastoreReader",
 		"datastoreWriter",
 		"postgres",

--- a/pkg/config/default-config.yml
+++ b/pkg/config/default-config.yml
@@ -25,9 +25,9 @@ defaultEnvironment:
   PRESENTER_HOST: backend
   PRESENTER_PORT: 9003
 
-  DATASTORE_READER_HOST: datastore-reader
+  DATASTORE_READER_HOST: datastoreReader
   DATASTORE_READER_PORT: 9010
-  DATASTORE_WRITER_HOST: datastore-writer
+  DATASTORE_WRITER_HOST: datastoreWriter
   DATASTORE_WRITER_PORT: 9011
   DATASTORE_DATABASE_HOST: postgres
   DATASTORE_DATABASE_PORT: 5432
@@ -76,6 +76,7 @@ defaultEnvironment:
   MANAGE_HOST: manage
   MANAGE_PORT: 9008
   MANAGE_AUTH_PASSWORD_FILE: /run/secrets/manage_auth_password
+  MANAGE_ACTION_HOST: backendManage
 
   INTERNAL_AUTH_PASSWORD_FILE: /run/secrets/internal_auth_password
 
@@ -88,8 +89,7 @@ defaultEnvironment:
 # defaultEnvironment:
 #   SOME_ENV_VAR: my value
 
-# You can customize single services using the services property. Service names
-# are written in camelCase.
+# You can customize single services using the services property.
 services:
   datastoreReader:
     environment:

--- a/pkg/config/default-docker-compose.yml
+++ b/pkg/config/default-docker-compose.yml
@@ -1,4 +1,6 @@
 ---
+version: "3.7"
+
 x-default-environment: &default-environment
   {{- marshalContent 2 .DefaultEnvironment }}
 
@@ -68,7 +70,6 @@ services:
     image: {{ .ContainerRegistry }}/openslides-backend:{{ .Tag }}
     {{- if checkFlag $.DisableDependsOn }}{{ else }}
     depends_on:
-      - datastore-reader
       - datastore-writer
       - auth
       - postgres
@@ -78,21 +79,18 @@ services:
       {{- with .Environment }}{{ marshalContent 6 . }}{{- end }}
     networks:
       - frontend
-      - datastore-reader
-      - datastore-writer
-      - postgres
+      - data
     secrets:
       - auth_token_key
       - auth_cookie_key
-      - internal_auth_password
       - postgres_password
     {{- with .AdditionalContent }}{{ marshalContent 4 . }}{{- end }}
   {{- end }}
 
 
-  {{- with .Services.backendSetup }}
+  {{- with .Services.backendManage }}
 
-  backend-setup:
+  backendManage:
     image: {{ .ContainerRegistry }}/openslides-backend:{{ .Tag }}
     {{- if checkFlag $.DisableDependsOn }}{{ else }}
     depends_on:
@@ -100,10 +98,9 @@ services:
     {{- end }}
     environment:
       << : *default-environment
+      {{- with .Environment }}{{ marshalContent 6 . }}{{- end }}
     networks:
-      - datastore-reader
-      - datastore-writer
-      - postgres
+      - data
     secrets:
       - auth_token_key
       - auth_cookie_key
@@ -115,7 +112,7 @@ services:
 
   {{- with .Services.datastoreReader }}
 
-  datastore-reader:
+  datastoreReader:
     image: {{ .ContainerRegistry }}/openslides-datastore-reader:{{ .Tag }}
     {{- if checkFlag $.DisableDependsOn }}{{ else }}
     depends_on:
@@ -125,8 +122,7 @@ services:
       << : *default-environment
       {{- with .Environment }}{{ marshalContent 6 . }}{{- end }}
     networks:
-      - datastore-reader
-      - postgres
+      - data
     secrets:
       - postgres_password
     {{- with .AdditionalContent }}{{ marshalContent 4 . }}{{- end }}
@@ -135,7 +131,7 @@ services:
 
   {{- with .Services.datastoreWriter }}
 
-  datastore-writer:
+  datastoreWriter:
     image: {{ .ContainerRegistry }}/openslides-datastore-writer:{{ .Tag }}
     {{- if checkFlag $.DisableDependsOn }}{{ else }}
     depends_on:
@@ -146,10 +142,7 @@ services:
       << : *default-environment
       {{- with .Environment }}{{ marshalContent 6 . }}{{- end }}
     networks:
-      - datastore-reader
-      - datastore-writer
-      - postgres
-      - redis
+      - data
     secrets:
       - postgres_password
     {{- with .AdditionalContent }}{{ marshalContent 4 . }}{{- end }}
@@ -168,7 +161,7 @@ services:
       POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
       PGDATA: /var/lib/postgresql/data/pgdata
     networks:
-      - postgres
+      - data
     secrets:
       - postgres_password
     volumes:
@@ -193,8 +186,7 @@ services:
       AUTH: ticket
     networks:
       - frontend
-      - datastore-reader
-      - redis
+      - data
     secrets:
       - auth_token_key
       - auth_cookie_key
@@ -216,8 +208,7 @@ services:
       {{- with .Environment }}{{ marshalContent 6 . }}{{- end }}
     networks:
       - frontend
-      - datastore-reader
-      - redis
+      - data
     secrets:
       - auth_token_key
       - auth_cookie_key
@@ -243,9 +234,7 @@ services:
       AUTH: ticket
     networks:
       - frontend
-      - datastore-reader
-      - postgres
-      - redis
+      - data
     secrets:
       - auth_token_key
       - auth_cookie_key
@@ -262,7 +251,7 @@ services:
       << : *default-environment
       {{- with .Environment }}{{ marshalContent 6 . }}{{- end }}
     networks:
-      - redis
+      - data
     {{- with .AdditionalContent }}{{ marshalContent 4 . }}{{- end }}
   {{- end }}
 
@@ -281,9 +270,7 @@ services:
       {{- with .Environment }}{{ marshalContent 6 . }}{{- end }}
     networks:
       - frontend
-      - datastore-reader
-      - datastore-writer
-      - postgres
+      - data
     secrets:
       - postgres_password
     {{- with .AdditionalContent }}{{ marshalContent 4 . }}{{- end }}
@@ -307,9 +294,7 @@ services:
       AUTH: ticket
     networks:
       - frontend
-      - datastore-reader
-      - postgres
-      - redis
+      - data
     secrets:
       - auth_token_key
       - auth_cookie_key
@@ -332,10 +317,7 @@ services:
       {{- with .Environment }}{{ marshalContent 6 . }}{{- end }}
     networks:
       - frontend
-      - datastore-reader
-      - datastore-writer
-      - postgres
-      - redis
+      - data
     secrets:
       - superadmin
       - manage_auth_password
@@ -347,13 +329,7 @@ networks:
   uplink:
   frontend:
     internal: true
-  datastore-reader:
-    internal: true
-  datastore-writer:
-    internal: true
-  postgres:
-    internal: true
-  redis:
+  data:
     internal: true
 
 secrets:

--- a/pkg/config/default-docker-compose.yml
+++ b/pkg/config/default-docker-compose.yml
@@ -90,6 +90,29 @@ services:
   {{- end }}
 
 
+  {{- with .Services.backendSetup }}
+
+  backend-setup:
+    image: {{ .ContainerRegistry }}/openslides-backend:{{ .Tag }}
+    {{- if checkFlag $.DisableDependsOn }}{{ else }}
+    depends_on:
+      - backend
+    {{- end }}
+    environment:
+      << : *default-environment
+    networks:
+      - datastore-reader
+      - datastore-writer
+      - postgres
+    secrets:
+      - auth_token_key
+      - auth_cookie_key
+      - internal_auth_password
+      - postgres_password
+    {{- with .AdditionalContent }}{{ marshalContent . }}{{- end }}
+  {{- end }}
+
+
   {{- with .Services.datastoreReader }}
 
   datastore-reader:

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -88,7 +88,7 @@ func (s *srv) InitialData(ctx context.Context, in *proto.InitialDataRequest) (*p
 	if err != nil {
 		return nil, fmt.Errorf("getting internal auth password from file: %w", err)
 	}
-	a := action.New(s.config.actionURL(), pw)
+	a := action.New(s.config.manageActionURL(), pw)
 	return initialdata.InitialData(ctx, in, runDir, a)
 
 }
@@ -98,7 +98,7 @@ func (s *srv) CreateUser(ctx context.Context, in *proto.CreateUserRequest) (*pro
 	if err != nil {
 		return nil, fmt.Errorf("getting internal auth password from file: %w", err)
 	}
-	a := action.New(s.config.actionURL(), pw)
+	a := action.New(s.config.manageActionURL(), pw)
 	return createuser.CreateUser(ctx, in, a)
 }
 
@@ -107,7 +107,7 @@ func (s *srv) SetPassword(ctx context.Context, in *proto.SetPasswordRequest) (*p
 	if err != nil {
 		return nil, fmt.Errorf("getting internal auth password from file: %w", err)
 	}
-	a := action.New(s.config.actionURL(), pw)
+	a := action.New(s.config.manageActionURL(), pw)
 	return setpassword.SetPassword(ctx, in, a)
 }
 
@@ -170,6 +170,8 @@ type Config struct {
 	ActionHost     string `env:"ACTION_HOST,backend"`
 	ActionPort     string `env:"ACTION_PORT,9002"`
 
+	ManageActionHost string `env:"MANAGE_ACTION_HOST,backendManage"`
+
 	AuthProtocol string `env:"AUTH_PROTOCOL,http"`
 	AuthHost     string `env:"AUTH_HOST,auth"`
 	AuthPort     string `env:"AUTH_PORT,9004"`
@@ -216,11 +218,11 @@ func ConfigFromEnv(loockup func(string) (string, bool)) *Config {
 	return &c
 }
 
-// actionURL returns an URL object to the backend action service.
-func (c *Config) actionURL() *url.URL {
+// manageActionURL returns an URL object to the backend action service.
+func (c *Config) manageActionURL() *url.URL {
 	u := url.URL{
 		Scheme: c.ActionProtocol,
-		Host:   c.ActionHost + ":" + c.ActionPort,
+		Host:   c.ManageActionHost + ":" + c.ActionPort,
 		Path:   "/internal/handle_request",
 	}
 	return &u


### PR DESCRIPTION
With the way the `migrations` route in the backend is currently implemented, it looks like we are going to need an extra backend service to handle migrations as the progress of an ongoing migration can only be asked from the specific container where it was started. And this would run into problems, if the main `backend` was scaled up.

For simple setups (i.e. where a scale=1 for the `backend` can always be assumed) we could have the this service optional using a config option similar to `disablePostgres`.

However having it in the stack brings another advantage:
When doing the 2-step migrations there must be a backend within the stack that is ahead in version of the other services.
By having a predefined service, this can be consistent and predictable (instead of adding another `backend` - which would be reachable under the same hostname as the "regular production" ones - and trying to distinguish between them).

With this I propose all requests from the manage-service should be called on `backend-setup` in the future, giving it clear semantic purpose.
Also I think with this the normal backend wouldn't even need the `internal_auth_password` as all internal routes are called on `backend-setup`

@normanjaeckel @gsiv @jsangmeister 
feel free to share your thoughts :)