### PR TITLE
Postgres related fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 docker-compose.yml
 config.yml
 secrets/
-db-data/
 /inst
 
 # Misc

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -173,8 +173,6 @@ type YmlConfig struct {
 	EnableLocalHTTPS *bool `yaml:"enableLocalHTTPS"`
 	EnableAutoHTTPS  *bool `yaml:"enableAutoHTTPS"`
 
-	PostgresContainerUser string `yaml:"postgresContainerUser"`
-
 	Defaults struct {
 		ContainerRegistry string `yaml:"containerRegistry"`
 		Tag               string `yaml:"tag"`
@@ -226,11 +224,6 @@ func NewYmlConfig(configFiles [][]byte) (*YmlConfig, error) {
 		if err := mergo.Merge(config, c, mergo.WithOverride, mergo.WithTransformers(&nullTransformer{})); err != nil {
 			return nil, fmt.Errorf("merging config files: %w", err)
 		}
-	}
-
-	// Add default PostgresContainerUser
-	if config.PostgresContainerUser == "" {
-		config.PostgresContainerUser = fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid())
 	}
 
 	// Fill services

--- a/pkg/config/default-config.yml
+++ b/pkg/config/default-config.yml
@@ -7,7 +7,6 @@ host: 127.0.0.1
 port: 8000
 
 # General global options
-postgresContainerUser: ""  # Must be of form <uid>:<gid>, empty strings means the service will detect the caller's user and group id.
 disablePostgres: false
 disableDependsOn: false
 enableLocalHTTPS: true

--- a/pkg/config/default-docker-compose.yml
+++ b/pkg/config/default-docker-compose.yml
@@ -364,6 +364,7 @@ networks:
 
 
 {{- if not (checkFlag .DisablePostgres) }}
+
 volumes:
   postgres-data:
 {{- end }}

--- a/pkg/config/default-docker-compose.yml
+++ b/pkg/config/default-docker-compose.yml
@@ -199,8 +199,6 @@ services:
     user: {{ $.PostgresContainerUser }}
     secrets:
       - postgres_password
-    volumes:
-      - ./db-data:/var/lib/postgresql/data
     {{- with .AdditionalContent }}{{ marshalContent 4 . }}{{- end }}
   {{- end }}{{- end }}
 

--- a/pkg/config/default-docker-compose.yml
+++ b/pkg/config/default-docker-compose.yml
@@ -196,7 +196,6 @@ services:
       POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
     networks:
       - data
-    user: {{ $.PostgresContainerUser }}
     secrets:
       - postgres_password
     {{- with .AdditionalContent }}{{ marshalContent 4 . }}{{- end }}

--- a/pkg/config/default-docker-compose.yml
+++ b/pkg/config/default-docker-compose.yml
@@ -194,7 +194,6 @@ services:
       POSTGRES_DB: openslides
       POSTGRES_USER: openslides
       POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
-      PGDATA: /var/lib/postgresql/data/pgdata
     networks:
       - data
     user: {{ $.PostgresContainerUser }}

--- a/pkg/config/default-docker-compose.yml
+++ b/pkg/config/default-docker-compose.yml
@@ -194,6 +194,8 @@ services:
       POSTGRES_DB: openslides
       POSTGRES_USER: openslides
       POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
     networks:
       - data
     secrets:
@@ -359,6 +361,12 @@ networks:
     internal: true
   data:
     internal: true
+
+
+{{- if not (checkFlag .DisablePostgres) }}
+volumes:
+  postgres-data:
+{{- end }}
 
 secrets:
   auth_token_key:

--- a/pkg/setup/setup.go
+++ b/pkg/setup/setup.go
@@ -24,7 +24,6 @@ import (
 
 const (
 	subDirPerms  fs.FileMode = 0770
-	dbDirName                = "db-data"
 	certCertName             = "cert_crt"
 	certKeyName              = "cert_key"
 )
@@ -138,14 +137,6 @@ func Setup(dir string, force bool, tplFile []byte, configFiles [][]byte) error {
 	// Create superadmin file
 	if err := shared.CreateFile(secrDir, force, SuperadminFileName, []byte(DefaultSuperadminPassword)); err != nil {
 		return fmt.Errorf("creating admin file at %q: %w", dir, err)
-	}
-
-	// Create database directory
-	// Attention: For unknown reason it is not possible to use perms 0770 here. Docker Compose does not like it ...
-	if !*cfg.DisablePostgres {
-		if err := os.MkdirAll(path.Join(dir, dbDirName), 0777); err != nil {
-			return fmt.Errorf("creating database directory at %q: %w", dir, err)
-		}
 	}
 
 	return nil

--- a/pkg/setup/setup_test.go
+++ b/pkg/setup/setup_test.go
@@ -647,7 +647,6 @@ services:
       POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
     networks:
       - data
-    user: %s
     secrets:
       - postgres_password
 
@@ -775,7 +774,7 @@ secrets:
     file: ./secrets/cert_crt
   cert_key:
     file: ./secrets/cert_key
-`, fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()))
+`)
 }
 
 func TestSetupNoDirectory(t *testing.T) {

--- a/pkg/setup/setup_test.go
+++ b/pkg/setup/setup_test.go
@@ -32,7 +32,6 @@ func TestCmd(t *testing.T) {
 		testKeyFile(t, secDir, "manage_auth_password")
 		testPasswordFile(t, secDir, "postgres_password")
 		testContentFile(t, secDir, setup.SuperadminFileName, setup.DefaultSuperadminPassword)
-		testDirectory(t, testDir, "db-data")
 	})
 
 	t.Run("executing setup.Cmd() with new directory with --force flag", func(t *testing.T) {
@@ -55,7 +54,6 @@ func TestCmd(t *testing.T) {
 		testKeyFile(t, secDir, "manage_auth_password")
 		testPasswordFile(t, secDir, "postgres_password")
 		testContentFile(t, secDir, setup.SuperadminFileName, setup.DefaultSuperadminPassword)
-		testDirectory(t, testDir, "db-data")
 	})
 
 	t.Run("executing setup.Cmd() with new directory with --template flag", func(t *testing.T) {
@@ -89,7 +87,6 @@ func TestCmd(t *testing.T) {
 		testKeyFile(t, secDir, "manage_auth_password")
 		testPasswordFile(t, secDir, "postgres_password")
 		testContentFile(t, secDir, setup.SuperadminFileName, setup.DefaultSuperadminPassword)
-		testDirectory(t, testDir, "db-data")
 	})
 
 	t.Run("executing setup.Cmd() with new directory with --config flag", func(t *testing.T) {
@@ -130,7 +127,6 @@ services:
 		testKeyFile(t, secDir, "manage_auth_password")
 		testPasswordFile(t, secDir, "postgres_password")
 		testContentFile(t, secDir, setup.SuperadminFileName, setup.DefaultSuperadminPassword)
-		testDirectory(t, testDir, "db-data")
 	})
 
 	t.Run("executing setup.Cmd() with new directory with --config flag twice", func(t *testing.T) {
@@ -182,7 +178,6 @@ defaults:
 		testKeyFile(t, secDir, "manage_auth_password")
 		testPasswordFile(t, secDir, "postgres_password")
 		testContentFile(t, secDir, setup.SuperadminFileName, setup.DefaultSuperadminPassword)
-		testDirectory(t, testDir, "db-data")
 	})
 
 }
@@ -205,7 +200,6 @@ func TestSetupCommon(t *testing.T) {
 		testKeyFile(t, secDir, "manage_auth_password")
 		testPasswordFile(t, secDir, "postgres_password")
 		testContentFile(t, secDir, setup.SuperadminFileName, setup.DefaultSuperadminPassword)
-		testDirectory(t, testDir, "db-data")
 	})
 
 	t.Run("running setup.Setup() twice without changing existant files", func(t *testing.T) {
@@ -229,7 +223,6 @@ func TestSetupCommon(t *testing.T) {
 		testKeyFile(t, secDir, "manage_auth_password")
 		testPasswordFile(t, secDir, "postgres_password")
 		testContentFile(t, secDir, setup.SuperadminFileName, setup.DefaultSuperadminPassword)
-		testDirectory(t, testDir, "db-data")
 	})
 
 	t.Run("running setup.Setup() with force flag with changing existant files", func(t *testing.T) {
@@ -243,7 +236,6 @@ func TestSetupCommon(t *testing.T) {
 		testKeyFile(t, secDir, "manage_auth_password")
 		testPasswordFile(t, secDir, "postgres_password")
 		testContentFile(t, secDir, setup.SuperadminFileName, setup.DefaultSuperadminPassword)
-		testDirectory(t, testDir, "db-data")
 	})
 }
 
@@ -266,7 +258,6 @@ func TestSetupNonExistingSubdirectory(t *testing.T) {
 		testKeyFile(t, secDir, "manage_auth_password")
 		testPasswordFile(t, secDir, "postgres_password")
 		testContentFile(t, secDir, setup.SuperadminFileName, setup.DefaultSuperadminPassword)
-		testDirectory(t, dir, "db-data")
 	})
 }
 
@@ -289,7 +280,6 @@ func TestSetupExternalTemplate(t *testing.T) {
 		testKeyFile(t, secDir, "manage_auth_password")
 		testPasswordFile(t, secDir, "postgres_password")
 		testContentFile(t, secDir, setup.SuperadminFileName, setup.DefaultSuperadminPassword)
-		testDirectory(t, testDir, "db-data")
 	})
 }
 
@@ -328,7 +318,6 @@ services:
 		testKeyFile(t, secDir, "manage_auth_password")
 		testPasswordFile(t, secDir, "postgres_password")
 		testContentFile(t, secDir, setup.SuperadminFileName, setup.DefaultSuperadminPassword)
-		testDirectory(t, testDir, "db-data")
 	})
 
 	t.Run("running setup.Setup() and create all stuff in tmp directory using another custom config", func(t *testing.T) {
@@ -470,15 +459,6 @@ func testPasswordFile(t testing.TB, dir, name string) {
 	p := path.Join(dir, name)
 	if _, err := os.Stat(p); errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("file %q does not exist, expected existance", p)
-	}
-}
-
-func testDirectory(t testing.TB, dir, name string) {
-	t.Helper()
-
-	subdir := path.Join(dir, name)
-	if _, err := os.Stat(subdir); err != nil {
-		t.Fatalf("missing (sub-)directory %q", subdir)
 	}
 }
 
@@ -670,8 +650,6 @@ services:
     user: %s
     secrets:
       - postgres_password
-    volumes:
-      - ./db-data:/var/lib/postgresql/data
 
   autoupdate:
     image: ghcr.io/openslides/openslides/openslides-autoupdate:latest

--- a/pkg/setup/setup_test.go
+++ b/pkg/setup/setup_test.go
@@ -645,6 +645,8 @@ services:
       POSTGRES_DB: openslides
       POSTGRES_USER: openslides
       POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
     networks:
       - data
     secrets:
@@ -756,6 +758,8 @@ networks:
     internal: true
   data:
     internal: true
+volumes:
+  postgres-data:
 
 secrets:
   auth_token_key:

--- a/pkg/setup/setup_test.go
+++ b/pkg/setup/setup_test.go
@@ -665,7 +665,6 @@ services:
       POSTGRES_DB: openslides
       POSTGRES_USER: openslides
       POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
-      PGDATA: /var/lib/postgresql/data/pgdata
     networks:
       - data
     user: %s

--- a/pkg/setup/setup_test.go
+++ b/pkg/setup/setup_test.go
@@ -758,6 +758,7 @@ networks:
     internal: true
   data:
     internal: true
+
 volumes:
   postgres-data:
 


### PR DESCRIPTION
this Pull Request includes these changes regarding the Postgres configuration:

1. Removes PGDATA variable from postgres service:
  - The documentation and commit history don't explain why a deviant path would be desirable and there's no technical plausbility.
2.  Don't expose Postgres' data in the project folder:
  - Neither docs nor commit history explain why this design was chosen.
  - Beside not complying with the usual usage of containers, this configuration breaks at least these scenarios:
    - User IDs from containers are dynamically mapped to user IDs on the host system.
      - Hence the data files aren't accessible for the Postgres process.
      - see https://docs.docker.com/engine/security/userns-remap/
    - In an environment where data is supposed to be held in specific storage volumes (e.g. /var/lib/docker on a separate storage device or Docker volumes on a remote filesystem) it doesn't comply, possibly flooding an
  undersized filesystem.
  - Users who want to expose the Postgres data folder at specific paths still can use the `additionalContent` key in a config file.