### PR TITLE
add postgres_password secret to autoupdate service

### DIFF
--- a/pkg/config/default-docker-compose.yml
+++ b/pkg/config/default-docker-compose.yml
@@ -224,6 +224,7 @@ services:
     secrets:
       - auth_token_key
       - auth_cookie_key
+      - postgres_password
     {{- with .AdditionalContent }}{{ marshalContent 4 . }}{{- end }}
   {{- end }}
 


### PR DESCRIPTION
As of
https://github.com/OpenSlides/openslides-autoupdate-service/commit/5e0cd06189e2a6a7d61e539cd5bb8117d9ef3384 the AU service will connect to postgres directly for fetching data. Therefore it now needs the postgres password.