### PR TITLE
Add uplink network to backendAction service

### DIFF
--- a/pkg/config/default-docker-compose.yml
+++ b/pkg/config/default-docker-compose.yml
@@ -85,6 +85,7 @@ services:
       {{- with .Environment }}{{ marshalContent 6 . }}{{- end }}
       OPENSLIDES_BACKEND_COMPONENT: action
     networks:
+      - uplink
       - frontend
       - data
     secrets:


### PR DESCRIPTION
This allows outbound SMTP traffic.

Fixes: https://github.com/OpenSlides/OpenSlides/issues/6469