### PR TITLE
Update restricter URL

### DIFF
--- a/pkg/config/default-config.yml
+++ b/pkg/config/default-config.yml
@@ -50,7 +50,7 @@ defaultEnvironment:
 
   SEARCH_SERVICE_HOST: search
   OPENSLIDES_SEARCH_PORT: 9050
-  OPENSLIDES_RESTRICTER: http://autoupdate:9012/internal/autoupdate/restrict_fqids
+  OPENSLIDES_RESTRICTER: http://autoupdate:9012/internal/autoupdate
 
   VOTE_HOST: vote
   VOTE_PORT: 9013

--- a/pkg/setup/setup_test.go
+++ b/pkg/setup/setup_test.go
@@ -511,7 +511,7 @@ x-default-environment: &default-environment
   OPENSLIDES_DB_USER: openslides
   OPENSLIDES_DEVELOPMENT: "false"
   OPENSLIDES_LOGLEVEL: info
-  OPENSLIDES_RESTRICTER: http://autoupdate:9012/internal/autoupdate/restrict_fqids
+  OPENSLIDES_RESTRICTER: http://autoupdate:9012/internal/autoupdate
   OPENSLIDES_SEARCH_PORT: "9050"
   PRESENTER_HOST: backendPresenter
   PRESENTER_PORT: "9003"


### PR DESCRIPTION
With https://github.com/OpenSlides/openslides-search-service/pull/29 the search service uses another URL to restrict results. Therefore the environment variable has to be changed accordingly.  
