### PR TITLE
Add auth-*-key secrets to media

### DIFF
--- a/pkg/config/default-docker-compose.yml
+++ b/pkg/config/default-docker-compose.yml
@@ -303,6 +303,8 @@ services:
       - frontend
       - data
     secrets:
+      - auth_token_key
+      - auth_cookie_key
       - postgres_password
     {{- with .AdditionalContent }}{{ marshalContent 4 . }}{{- end }}
   {{- end }}

--- a/pkg/setup/setup_test.go
+++ b/pkg/setup/setup_test.go
@@ -713,6 +713,8 @@ services:
       - frontend
       - data
     secrets:
+      - auth_token_key
+      - auth_cookie_key
       - postgres_password
 
   icc:


### PR DESCRIPTION
Required since https://github.com/OpenSlides/openslides-media-service/pull/70