### PR TITLE
Manage versioning

### DIFF
--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -2,6 +2,9 @@ name: GitHub Release (reusable)
 on:
   workflow_call:
     inputs:
+      branch:
+        type: string
+        default: main
       tag:
         type: string
         default: dev
@@ -24,6 +27,8 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
+      with:
+        ref: "${{ inputs.branch }}"
 
     - name: Build binaries
       run: go build ./cmd/openslides

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -1,7 +1,17 @@
-name: GitHub Release
+name: GitHub Release (reusable)
 on:
-  push:
-    branches: [main]
+  workflow_call:
+    inputs:
+      tag:
+        type: string
+        default: dev
+      title:
+        type: string
+        default: Development Build
+      prerelease:
+        type: boolean
+        default: true
+
 jobs:
   release:
     name: Create GitHub Release and upload binary
@@ -22,8 +32,8 @@ jobs:
       uses: marvinpinto/action-automatic-releases@latest
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "latest"
-        prerelease: true
-        title: "Development Build"
+        automatic_release_tag: "${{ inputs.tag }}"
+        prerelease: "${{ inputs.prerelease }}"
+        title: "${{ inputs.title }}"
         files: |
           openslides

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -1,0 +1,9 @@
+name: GitHub Release (dev)
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release-dev:
+    name: "Create dev Release"
+    uses: ./.github/workflows/release-create.yml

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -1,0 +1,26 @@
+name: GitHub Release (stable)
+on:
+  registry_package:
+    types: [updated]
+
+#  build-manage:
+#    name: "Build openslides binary (tag: 4.x.x)"
+#    if: startsWith(github.ref_name, 'stable/4')
+#    uses: peb-adr/openslides-manage-service/.github/workflows/release.yml@main
+
+
+jobs:
+  print-stuff:
+    steps:
+      - first:
+        run: |
+          echo "${{ to_json(github.event) }}" | jq .
+  release-stable: 
+    name: Create GitHub Release and upload binary
+    if: github.event.registry_package.package_version.container_metadata.tag.name != ''
+    runs-on: ubuntu-latest
+    uses: ./.github/workflows/release-create.yml
+    with:
+      tag: latest
+      title: Stable Build
+      prerelease: false

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -1,7 +1,9 @@
 name: GitHub Release (stable)
 on:
   registry_package:
-    types: [updated]
+    types:
+      - updated
+      - published
 
 #  build-manage:
 #    name: "Build openslides binary (tag: 4.x.x)"

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -1,7 +1,7 @@
 name: GitHub Release (stable)
 on:
   repository_dispatch:
-    types: [new-update]
+    types: [stable-update]
 
 jobs:
   release-stable:

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -1,28 +1,31 @@
 name: GitHub Release (stable)
 on:
-  package:
-    types:
-      - updated
-      - published
-
-#  build-manage:
-#    name: "Build openslides binary (tag: 4.x.x)"
-#    if: startsWith(github.ref_name, 'stable/4')
-#    uses: peb-adr/openslides-manage-service/.github/workflows/release.yml@main
-
+  repository_dispatch:
+    types: [new-update]
 
 jobs:
   print-stuff:
-    steps:
-      - first:
-        run: |
-          echo "${{ to_json(github.event) }}" | jq .
-  release-stable: 
-    name: Create GitHub Release and upload binary
-    if: github.event.registry_package.package_version.container_metadata.tag.name != ''
     runs-on: ubuntu-latest
+    steps:
+      - name: first
+        run: |
+          echo "${{ toJSON(github.event) }}"
+
+  release-stable:
+    name: "Create GitHub Release (4.x.x) and upload binary"
+    if: startsWith(github.event.client_payload.branch, 'stable/4')
     uses: ./.github/workflows/release-create.yml
     with:
+      branch: "${{ github.event.client_payload.branch }}"
+      tag: "${{ github.event.client_payload.version }}"
+      title: Stable Build
+      prerelease: false
+  release-stable-latest:
+    name: "Create GitHub Release (latest) and upload binary"
+    if: startsWith(github.event.client_payload.branch, 'stable/4')
+    uses: ./.github/workflows/release-create.yml
+    with:
+      branch: "${{ github.event.client_payload.branch }}"
       tag: latest
       title: Stable Build
       prerelease: false

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -4,13 +4,6 @@ on:
     types: [new-update]
 
 jobs:
-  print-stuff:
-    runs-on: ubuntu-latest
-    steps:
-      - name: first
-        run: |
-          echo "${{ toJSON(github.event) }}"
-
   release-stable:
     name: "Create GitHub Release (4.x.x) and upload binary"
     if: startsWith(github.event.client_payload.branch, 'stable/4')

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -1,6 +1,6 @@
 name: GitHub Release (stable)
 on:
-  registry_package:
+  package:
     types:
       - updated
       - published

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ LABEL org.opencontainers.image.title="OpenSlides Manage Service"
 LABEL org.opencontainers.image.description="Manage service and tool for OpenSlides which \
 provides some management commands to setup and control OpenSlides instances."
 LABEL org.opencontainers.image.licenses="MIT"
-LABEL org.opencontainers.image.source="https://github.com/peb-adr/openslides-manage-service"
+LABEL org.opencontainers.image.source="https://github.com/OpenSlides/openslides-manage-service"
 LABEL org.opencontainers.image.documentation="https://github.com/OpenSlides/openslides-manage-service/blob/main/README.md"
 
 COPY --from=builder /root/healthcheck .

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ LABEL org.opencontainers.image.title="OpenSlides Manage Service"
 LABEL org.opencontainers.image.description="Manage service and tool for OpenSlides which \
 provides some management commands to setup and control OpenSlides instances."
 LABEL org.opencontainers.image.licenses="MIT"
-LABEL org.opencontainers.image.source="https://github.com/OpenSlides/openslides-manage-service"
+LABEL org.opencontainers.image.source="https://github.com/peb-adr/openslides-manage-service"
 LABEL org.opencontainers.image.documentation="https://github.com/OpenSlides/openslides-manage-service/blob/main/README.md"
 
 COPY --from=builder /root/healthcheck .


### PR DESCRIPTION
Change workflows for release creation such that it can be triggered by the main repository via repository_dispatch.
This way for every stable release a compatible version of the manage tool is build and kept separately.

Commits on main are still build (as before) but are now tagged as `dev` instead of `latest` this was leading to annoying incompatibilities.