### PR TITLE
Remove `SYSTEM_URL`

### DIFF
--- a/pkg/config/default-config.yml
+++ b/pkg/config/default-config.yml
@@ -81,7 +81,6 @@ defaultEnvironment:
 
   OPENSLIDES_LOGLEVEL: info
   OPENSLIDES_DEVELOPMENT: "false"
-  SYSTEM_URL: localhost:8000
 
 # You can extend or replace parts of the defaultEnvironment.
 #

--- a/pkg/setup/setup_test.go
+++ b/pkg/setup/setup_test.go
@@ -509,7 +509,6 @@ x-default-environment: &default-environment
   SEARCH_HOST: search
   SEARCH_PORT: "9050"
   SUPERADMIN_PASSWORD_FILE: /run/secrets/superadmin
-  SYSTEM_URL: localhost:8000
   VOTE_DATABASE_HOST: postgres
   VOTE_DATABASE_NAME: openslides
   VOTE_DATABASE_PASSWORD_FILE: /run/secrets/postgres_password


### PR DESCRIPTION
see https://github.com/OpenSlides/OpenSlides/issues/6689

It seems the variable was added but never used. The relevant URL is saved in `organization/url`.